### PR TITLE
Add FastAPI backend with chat endpoints

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from .models import ChatRequest
+
+router = APIRouter()
+
+
+@router.post("/")
+async def chat(request: ChatRequest) -> dict:
+    """Simple REST endpoint that echoes back a combined message."""
+    reply = " ".join(message.content for message in request.messages)
+    return {"reply": reply}
+
+
+@router.websocket("/ws")
+async def chat_ws(websocket: WebSocket) -> None:
+    """Echo back incoming text as tokenized JSON messages."""
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            for token in data.split():
+                await websocket.send_json({"token": token})
+    except WebSocketDisconnect:
+        pass

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    messages: List[Message]

--- a/backend/api/router.py
+++ b/backend/api/router.py
@@ -1,0 +1,6 @@
+from fastapi import APIRouter
+
+from .chat import router as chat_router
+
+api_router = APIRouter()
+api_router.include_router(chat_router, prefix="/chat", tags=["chat"])

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from backend.api.router import api_router
+
+
+def create_app() -> FastAPI:
+    """Application factory for FastAPI."""
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.include_router(api_router)
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
- add FastAPI application factory with CORS
- implement chat REST and WebSocket handlers
- define Pydantic models and aggregate routing

## Testing
- `python -m py_compile backend/main.py backend/api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0b4edba748325bc53244128a2db6f