### PR TITLE
Add async memory and embedding utilities

### DIFF
--- a/backend/memory/__init__.py
+++ b/backend/memory/__init__.py
@@ -1,0 +1,6 @@
+"""Memory backend utilities."""
+
+from .chroma_client import VectorStoreClient
+from .embedder import Embedder
+
+__all__ = ["VectorStoreClient", "Embedder"]

--- a/backend/memory/chroma_client.py
+++ b/backend/memory/chroma_client.py
@@ -1,0 +1,155 @@
+"""Asynchronous vector store client supporting ChromaDB and Qdrant."""
+
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+
+class VectorStoreClient:
+    """Simple abstraction over ChromaDB and Qdrant vector stores.
+
+    Parameters
+    ----------
+    config:
+        Configuration dictionary. Must contain the key ``backend`` with value
+        either ``"chroma"`` or ``"qdrant"``. Backend specific settings are
+        also read from this dictionary.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        self.backend = config.get("backend", "chroma").lower()
+        if self.backend == "chroma":
+            self._client = self._init_chroma(config)
+        elif self.backend == "qdrant":
+            self._client = self._init_qdrant(config)
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"Unsupported backend: {self.backend}")
+
+    # ------------------------------------------------------------------
+    # backend initialisation helpers
+    def _init_chroma(self, config: Dict[str, Any]):
+        try:
+            import chromadb
+            from chromadb.config import Settings
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError("chromadb is required for Chroma backend") from exc
+
+        persist_dir = config.get("persist_directory")
+        settings = Settings(chroma_db_impl="duckdb+parquet", persist_directory=persist_dir)
+        return chromadb.Client(settings)
+
+    def _init_qdrant(self, config: Dict[str, Any]):
+        try:
+            from qdrant_client import QdrantClient
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError("qdrant-client is required for Qdrant backend") from exc
+
+        url = config.get("url", "http://localhost:6333")
+        api_key = config.get("api_key")
+        return QdrantClient(url=url, api_key=api_key)
+
+    # ------------------------------------------------------------------
+    async def add_vectors(
+        self,
+        collection: str,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        metadatas: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> None:
+        """Add embeddings to the vector store."""
+
+        if self.backend == "chroma":
+            await self._add_chroma(collection, ids, vectors, metadatas)
+        else:
+            await self._add_qdrant(collection, ids, vectors, metadatas)
+
+    async def _add_chroma(
+        self,
+        collection: str,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        metadatas: Optional[Sequence[Dict[str, Any]]],
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        coll = await loop.run_in_executor(
+            None, self._client.get_or_create_collection, collection
+        )
+        add = partial(
+            coll.add,
+            ids=list(ids),
+            embeddings=[list(v) for v in vectors],
+            metadatas=list(metadatas) if metadatas is not None else None,
+        )
+        await loop.run_in_executor(None, add)
+
+    async def _add_qdrant(
+        self,
+        collection: str,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        metadatas: Optional[Sequence[Dict[str, Any]]],
+    ) -> None:
+        try:
+            from qdrant_client.http.models import PointStruct
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError("qdrant-client is required for Qdrant backend") from exc
+
+        points = [
+            PointStruct(id=id_, vector=list(vec), payload=meta or {})
+            for id_, vec, meta in zip(ids, vectors, metadatas or [{}] * len(ids))
+        ]
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._client.upsert, collection, points)
+
+    # ------------------------------------------------------------------
+    async def query(
+        self, collection: str, vector: Sequence[float], *, n_results: int = 3
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        """Query the vector store and return list of (id, score, metadata)."""
+
+        if self.backend == "chroma":
+            return await self._query_chroma(collection, vector, n_results)
+        else:
+            return await self._query_qdrant(collection, vector, n_results)
+
+    async def _query_chroma(
+        self, collection: str, vector: Sequence[float], n_results: int
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        loop = asyncio.get_running_loop()
+        coll = await loop.run_in_executor(
+            None, self._client.get_or_create_collection, collection
+        )
+        query = partial(
+            coll.query,
+            query_embeddings=[list(vector)],
+            n_results=n_results,
+        )
+        res = await loop.run_in_executor(None, query)
+        ids = res.get("ids", [[]])[0]
+        distances = res.get("distances", [[]])[0]
+        metas = res.get("metadatas", [[]])[0]
+        return [(id_, dist, meta) for id_, dist, meta in zip(ids, distances, metas)]
+
+    async def _query_qdrant(
+        self, collection: str, vector: Sequence[float], n_results: int
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        loop = asyncio.get_running_loop()
+        res = await loop.run_in_executor(
+            None,
+            self._client.search,
+            collection,
+            list(vector),
+            n_results,
+            True,
+        )
+        return [
+            (str(p.id), float(p.score), dict(p.payload or {}))
+            for p in res
+        ]
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "VectorStoreClient":
+        return cls(config)

--- a/backend/memory/embedder.py
+++ b/backend/memory/embedder.py
@@ -1,0 +1,51 @@
+import asyncio
+from typing import List, Dict, Optional
+
+try:
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - optional dependency
+    SentenceTransformer = None  # type: ignore
+
+
+_MODEL_MAP = {
+    "MiniLM": "all-MiniLM-L6-v2",
+    "BGE": "bge-small-en",
+}
+
+
+class Embedder:
+    """Wrapper around :mod:`sentence_transformers` models.
+
+    Parameters
+    ----------
+    model_key:
+        Key identifying which embedding model to load. Supported keys are
+        ``"MiniLM"`` and ``"BGE"`` but any valid SentenceTransformer model
+        name may be provided.
+    device:
+        Optional device identifier passed to SentenceTransformer.
+    """
+
+    def __init__(self, model_key: str = "MiniLM", *, device: Optional[str] = None):
+        if SentenceTransformer is None:  # pragma: no cover - dependency not installed
+            raise ImportError(
+                "sentence-transformers package is required for Embedder"
+            )
+
+        model_name = _MODEL_MAP.get(model_key, model_key)
+        self._model = SentenceTransformer(model_name, device=device)
+
+    async def embed(self, text: str) -> List[float]:
+        """Asynchronously embed ``text`` returning a list of floats."""
+
+        loop = asyncio.get_running_loop()
+        vector = await loop.run_in_executor(None, self._model.encode, text)
+        return vector.tolist() if hasattr(vector, "tolist") else list(vector)
+
+    @classmethod
+    def from_config(cls, config: Dict[str, str]) -> "Embedder":
+        """Create an :class:`Embedder` from a configuration mapping."""
+
+        model_key = config.get("model", "MiniLM")
+        device = config.get("device")
+        return cls(model_key=model_key, device=device)


### PR DESCRIPTION
## Summary
- add asynchronous vector store client supporting ChromaDB and Qdrant backends
- introduce sentence-transformers embedder selectable via config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b4eff3b88325b40eb0e826bf2c2b