### PR TITLE
Add Docker scaffolding and usage instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+# Copy this file to .env and adjust values as needed
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # VEX-Modular-AI-Stack
 VEX's modular AI stack build that will include back and frontend API behaviour, personality core injection, local and OpenRouter model switching, RAG and agentic pipelines and more.
+
+## Installation
+1. Clone this repository.
+2. (Optional) Create a Python virtual environment.
+3. Install dependencies if a `requirements.txt` file is present:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Running locally
+Start the backend:
+```bash
+python main.py
+```
+
+If you have a frontend, start it in another terminal:
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Docker usage
+A Docker setup is provided to run the backend and a Node-based frontend.
+
+1. Copy `.env.example` to `.env` and update the values.
+2. Place any model files in the `models` directory.
+3. Build and start the stack:
+   ```bash
+   cd docker
+   docker compose up
+   ```
+
+The compose file mounts the `models` directory and `.env.example` into the backend container. The backend listens on port 8000 and the frontend on port 3000.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy project files
+COPY . .
+
+# Install dependencies if present
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    fi
+
+EXPOSE 8000
+
+CMD ["python", "main.py"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    volumes:
+      - ../models:/app/models
+      - ../.env.example:/app/.env.example
+    ports:
+      - "8000:8000"
+
+  frontend:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ../frontend:/app
+    ports:
+      - "3000:3000"
+    command: npm start
+    depends_on:
+      - backend


### PR DESCRIPTION
## Summary
- add backend Dockerfile and docker-compose config for backend/frontend
- provide example env file and models volume mount
- document installation and Docker usage in README

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b4f8294083259e278b488a0cf0c0