### PR TITLE
feat: integrate VexRouter into chat endpoints

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,25 +1,49 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
 
+from ..agents.vex_router import VexRouter
 from .models import ChatRequest
 
 router = APIRouter()
 
 
 @router.post("/")
-async def chat(request: ChatRequest) -> dict:
-    """Simple REST endpoint that echoes back a combined message."""
-    reply = " ".join(message.content for message in request.messages)
-    return {"reply": reply}
+async def chat(request: ChatRequest):
+    """Process messages via :class:`VexRouter`, optionally streaming."""
+    user_message = request.messages[-1].content if request.messages else ""
+    vex_router = VexRouter()
+    vex_router.set_remote(request.remote)
+
+    if request.stream:
+        generator = await vex_router.handle_message(user_message, stream=True)
+        return StreamingResponse(generator, media_type="text/plain")
+
+    reply = await vex_router.handle_message(user_message, stream=False)
+    if isinstance(reply, str):
+        return {"reply": reply}
+    return {"reply": ""}
 
 
 @router.websocket("/ws")
 async def chat_ws(websocket: WebSocket) -> None:
-    """Echo back incoming text as tokenized JSON messages."""
+    """WebSocket interface backed by :class:`VexRouter`."""
+    stream = websocket.query_params.get("stream", "true").lower() == "true"
+    remote = websocket.query_params.get("remote", "false").lower() == "true"
+
     await websocket.accept()
+    vex_router = VexRouter()
+    vex_router.set_remote(remote)
     try:
         while True:
             data = await websocket.receive_text()
-            for token in data.split():
-                await websocket.send_json({"token": token})
+            result = await vex_router.handle_message(data, stream=stream)
+            if stream:
+                async for token in result:
+                    await websocket.send_json({"token": token})
+            else:
+                if isinstance(result, str):
+                    await websocket.send_json({"reply": result})
+                else:
+                    await websocket.send_json({"reply": ""})
     except WebSocketDisconnect:
         pass

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -9,3 +9,5 @@ class Message(BaseModel):
 
 class ChatRequest(BaseModel):
     messages: List[Message]
+    stream: bool = False
+    remote: bool = False


### PR DESCRIPTION
## Summary
- route chat requests through VexRouter with optional streaming support
- allow selecting remote or local models for REST and WebSocket endpoints
- add stream and remote flags to chat request model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0b8cee1888325a58e5e2228a71d9e