### PR TITLE
docs: expand quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,33 @@
 # VEX-Modular-AI-Stack
 VEX's modular AI stack build that will include back and frontend API behaviour, personality core injection, local and OpenRouter model switching, RAG and agentic pipelines and more.
 
-## Installation
+## Setup
 1. Clone this repository.
 2. (Optional) Create a Python virtual environment.
-3. Install dependencies if a `requirements.txt` file is present:
-   ```bash
-   pip install -r requirements.txt
-   ```
+3. Copy `.env.example` to `.env` and update the values.
+4. Place any model files in the `models` directory.
 
-## Running locally
-Start the backend:
+## Quick Start
+
+### Backend
 ```bash
+cd backend
+pip install -r requirements.txt
 python main.py
 ```
 
-If you have a frontend, start it in another terminal:
+### Frontend
 ```bash
 cd frontend
 npm install
 npm run dev
 ```
 
-## Docker usage
-A Docker setup is provided to run the backend and a Node-based frontend.
+### Docker Compose
+```bash
+cp .env.example .env
+cd docker
+docker compose up
+```
 
-1. Copy `.env.example` to `.env` and update the values.
-2. Place any model files in the `models` directory.
-3. Build and start the stack:
-   ```bash
-   cd docker
-   docker compose up
-   ```
-
-The compose file mounts the `models` directory and `.env.example` into the backend container. The backend listens on port 8000 and the frontend on port 3000.
+The compose file mounts the `models` directory and `.env` into the backend container. The backend listens on port 8000 and the frontend on port 3000.


### PR DESCRIPTION
## Summary
- document copying `.env.example` before running the stack
- add quick start sections for backend, frontend, and Docker compose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0b8cfd7a88325b82be93fdbd461fc