### PR TITLE
Expand environment configuration and settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,22 @@
 # Example environment variables
 # Copy this file to .env and adjust values as needed
+# API key for OpenAI
 OPENAI_API_KEY=
+
+# API key for OpenRouter
+OPENROUTER_API_KEY=
+
+# API key for Anthropic
+ANTHROPIC_API_KEY=
+
+# Path to local model files
+LOCAL_MODEL_PATH=./models
+
+# Embedding model identifier
+EMBEDDING_MODEL=text-embedding-3-large
+
+# Vector store backend
+VECTOR_BACKEND=faiss
+
+# Enable GPU acceleration (true/false)
+USE_GPU=false

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,22 @@
 # Example environment configuration
+# API key for OpenAI
 OPENAI_API_KEY=your-openai-api-key
+
+# API key for OpenRouter
+OPENROUTER_API_KEY=your-openrouter-api-key
+
+# API key for Anthropic
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Path to local model files
+LOCAL_MODEL_PATH=/app/models
+
+# Embedding model identifier
+EMBEDDING_MODEL=text-embedding-3-large
+
+# Vector store backend
+VECTOR_BACKEND=faiss
+
+# Enable GPU acceleration (true/false)
 USE_GPU=false
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -14,9 +14,16 @@ class Settings(BaseSettings):
     # Paths
     base_path: Path = BASE_DIR
     models_path: Path = BASE_DIR.parent / 'models'
+    local_model_path: Path | None = None
 
     # API keys
     openai_api_key: str | None = None
+    openrouter_api_key: str | None = None
+    anthropic_api_key: str | None = None
+
+    # Model settings
+    embedding_model: str | None = 'text-embedding-3-large'
+    vector_backend: str | None = 'faiss'
 
     # Feature flags
     use_gpu: bool = False

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,14 @@ services:
       - ../.env.example:/app/.env.example
     ports:
       - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - LOCAL_MODEL_PATH=${LOCAL_MODEL_PATH}
+      - EMBEDDING_MODEL=${EMBEDDING_MODEL}
+      - VECTOR_BACKEND=${VECTOR_BACKEND}
+      - USE_GPU=${USE_GPU}
 
   frontend:
     image: node:20


### PR DESCRIPTION
## Summary
- document OpenRouter, Anthropic, model path and vector configuration in env examples
- expose new environment keys in backend settings
- wire backend service in docker-compose to pass the new keys

## Testing
- `python -m pytest`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0bc8f57c08325acb16a7ac0a2633f