### PR TITLE
Install backend requirements during Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,13 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Copy dependency file and install
+COPY backend/requirements.txt ./backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
+
 # Copy project files
 COPY . .
 
-# Install dependencies if present
-RUN if [ -f requirements.txt ]; then \
-        pip install --no-cache-dir -r requirements.txt; \
-    fi
-
 EXPOSE 8000
 
-CMD ["python", "main.py"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy and install `backend/requirements.txt` in Docker image
- run backend via uvicorn at port 8000

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `docker build` (docker not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68c0bc92aba48325a6c5b45b328afb0e