### PR TITLE
Add configuration API endpoints

### DIFF
--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter()
+
+# In-memory configuration storage
+_config: dict[str, Optional[str] | bool] = {"openai_api_key": None, "mode": "local"}
+
+def _verify_token(x_token: str = Header(...)) -> None:
+    """Very small token based auth guard."""
+    expected = os.getenv("CONFIG_TOKEN", "secret-token")
+    if x_token != expected:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+class ConfigRequest(BaseModel):
+    openai_api_key: Optional[str] = None
+    mode: str
+
+
+@router.post("/", dependencies=[Depends(_verify_token)])
+async def set_config(cfg: ConfigRequest) -> dict[str, Optional[str] | bool]:
+    """Update configuration for API keys and model mode."""
+    _config["openai_api_key"] = cfg.openai_api_key
+    _config["mode"] = cfg.mode
+    return _config
+
+
+@router.get("/", dependencies=[Depends(_verify_token)])
+async def get_config() -> dict[str, Optional[str] | bool]:
+    """Return the current configuration."""
+    return _config

--- a/backend/api/router.py
+++ b/backend/api/router.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 
 from .chat import router as chat_router
+from .config import router as config_router
 
 api_router = APIRouter()
 api_router.include_router(chat_router, prefix="/chat", tags=["chat"])
+api_router.include_router(config_router, prefix="/config", tags=["config"])


### PR DESCRIPTION
## Summary
- add `/api/config` endpoints for storing API keys and model mode
- secure config endpoints with simple header token authentication
- expose new config router via main API router

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0c4ce00688325bf7db126c397ffe0