### PR TITLE
docs: expand backend env example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,22 @@
 # Example environment configuration
-OPENAI_API_KEY=your-openai-api-key
-USE_GPU=false
 
+# API key for OpenAI models
+OPENAI_API_KEY=your-openai-api-key
+
+# Path to the local model used for offline inference
+LOCAL_MODEL_PATH=./models/your-model
+
+# API key for OpenRouter provider
+OPENROUTER_API_KEY=your-openrouter-api-key
+
+# API key for Anthropic Claude models
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Embedding model identifier for vector operations
+EMBEDDING_MODEL=text-embedding-3-large
+
+# Backend for vector storage (e.g., 'chroma', 'pinecone')
+VECTOR_BACKEND=chroma
+
+# Set to 'true' to enable GPU acceleration
+USE_GPU=false


### PR DESCRIPTION
## Summary
- add local model, provider, and vector backend settings to backend `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b8cce9388325ae2a603f2a89f269