### PR TITLE
Handle JSON websocket payload and stream

### DIFF
--- a/frontend/src/Chat.jsx
+++ b/frontend/src/Chat.jsx
@@ -12,7 +12,15 @@ const Chat = ({ onStatusChange }) => {
     wsRef.current = createWebSocket({
       onOpen: () => onStatusChange && onStatusChange('Connected'),
       onClose: () => onStatusChange && onStatusChange('Disconnected'),
-      onMessage: (token) => setStream((prev) => prev + token),
+      onMessage: (data) => {
+        if (data.token) {
+          setStream((prev) => prev + data.token);
+        }
+        if (data.reply) {
+          setMessages((prev) => [...prev, { role: 'assistant', content: data.reply }]);
+          setStream('');
+        }
+      },
     });
     return () => wsRef.current && wsRef.current.close();
   }, [onStatusChange]);

--- a/frontend/src/websocket.js
+++ b/frontend/src/websocket.js
@@ -1,7 +1,7 @@
 export function createWebSocket({ onMessage, onOpen, onClose }) {
   const ws = new WebSocket('ws://localhost:8000/api/chat/ws');
   if (onMessage) {
-    ws.onmessage = (event) => onMessage(event.data);
+    ws.onmessage = (event) => onMessage(JSON.parse(event.data));
   }
   if (onOpen) {
     ws.onopen = onOpen;


### PR DESCRIPTION
## Summary
- Parse JSON messages in websocket interface and toggle remote mode per request
- Stream tokens over websocket with final reply to mark completion
- Update frontend websocket client to send/receive JSON and handle token/reply separation

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0cf36c2c08325a35ff5af929a42c6