### PR TITLE
Expose Vite dev server on 5173

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - ../frontend:/app
     ports:
-      - "3000:3000"
-    command: npm start
+      - "5173:5173"
+    command: npm run dev
     depends_on:
       - backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests\" && exit 0"
+    "test": "echo \"No tests\" && exit 0",
+    "start": "vite build && vite preview --port 5173"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- route frontend through Vite's default dev port and run dev script in Docker
- add a start script to package.json for production builds on port 5173

## Testing
- `npm test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cf37f6bc8325962b46865f74ec0a