### PR TITLE
Support root .env in backend settings

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -9,7 +9,10 @@ class Settings(BaseSettings):
     Loads variables from ``.env`` and provides default paths and flags.
     """
 
-    model_config = SettingsConfigDict(env_file=BASE_DIR / '.env', env_file_encoding='utf-8')
+    model_config = SettingsConfigDict(
+        env_file=[BASE_DIR.parent / '.env', BASE_DIR / '.env'],
+        env_file_encoding='utf-8',
+    )
 
     # Paths
     base_path: Path = BASE_DIR


### PR DESCRIPTION
## Summary
- allow backend to load environment variables from project root `.env`

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c0cf39265483258a4b173d0bb76815