### PR TITLE
Align setup script and docs; add CI test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,15 @@
-# Example environment variables
-# Copy this file to .env and adjust values as needed
+# Example environment configuration
 # API key for OpenAI
-OPENAI_API_KEY=
+OPENAI_API_KEY=your-openai-api-key
 
 # API key for OpenRouter
-OPENROUTER_API_KEY=
+OPENROUTER_API_KEY=your-openrouter-api-key
 
 # API key for Anthropic
-ANTHROPIC_API_KEY=
+ANTHROPIC_API_KEY=your-anthropic-api-key
 
 # Path to local model files
-LOCAL_MODEL_PATH=./models
+LOCAL_MODEL_PATH=./models/local-models/ggml-model.gguf
 
 # Embedding model identifier
 EMBEDDING_MODEL=text-embedding-3-large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ cd docker
 docker compose up
 ```
 
-The compose file mounts the `models` directory and `.env` into the backend container. The backend listens on port 8000 and the frontend on port 3000.
+The compose file mounts the `models` directory and `.env` into the backend container. The backend listens on port 8000 and the frontend on port 5173.

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,10 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(api_router)
+
+    @app.get("/")
+    async def root() -> dict[str, str]:
+        return {"status": "ok"}
     return app
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ llama-cpp-python==0.3.16
 sentence-transformers==5.1.0
 chromadb==1.0.20
 qdrant-client==1.15.1
+pytest==8.1.1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,7 +16,7 @@ cd "$REPO_ROOT"
 # Configure environment file
 ENV_FILE="$REPO_ROOT/.env"
 if [ ! -f "$ENV_FILE" ]; then
-    cp backend/.env.example "$ENV_FILE"
+    cp .env.example "$ENV_FILE"
 fi
 
 read -p "Enter OpenRouter API key: " openrouter_key

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from fastapi.testclient import TestClient
+from backend.main import app
+
+
+def test_root_endpoint():
+    client = TestClient(app)
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- Fix setup script to copy root `.env.example`
- Correct README Docker port description
- Add root healthcheck endpoint and pytest-based CI

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b212e34483259bd6823e0f717fc5