### PR TITLE
Integrate chat component and refine UI layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,17 +1,20 @@
 import React, { useState } from 'react';
+import Chat from './Chat';
 import NeuroHUD from './NeuroHUD';
 import SettingsPanel from './components/SettingsPanel';
 import './styles.css';
 
 function App() {
   const [showSettings, setShowSettings] = useState(false);
+  const [status, setStatus] = useState('Disconnected');
 
   return (
     <div className="app">
       <button className="settings-toggle" onClick={() => setShowSettings(true)}>
         Settings
       </button>
-      <NeuroHUD />
+      <Chat onStatusChange={setStatus} />
+      <NeuroHUD status={status} />
       {showSettings && <SettingsPanel onClose={() => setShowSettings(false)} />}
     </div>
   );

--- a/frontend/src/NeuroHUD.jsx
+++ b/frontend/src/NeuroHUD.jsx
@@ -1,13 +1,9 @@
-import React, { useState } from 'react';
-import Chat from './Chat';
+import React from 'react';
 import StatusBar from './components/StatusBar';
 
-const NeuroHUD = () => {
-  const [status, setStatus] = useState('Disconnected');
-
+const NeuroHUD = ({ status }) => {
   return (
     <div className="neurohud">
-      <Chat onStatusChange={setStatus} />
       <StatusBar status={status} />
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -9,12 +9,19 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .neurohud {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  width: 100%;
+}
+
+.chat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .log-panel {
@@ -50,6 +57,23 @@ body {
   padding: 0.25rem 0.5rem;
   font-size: 0.8rem;
   text-align: right;
+}
+
+.settings-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+}
+
+.settings-panel {
+  position: absolute;
+  top: 50px;
+  right: 10px;
+  background: #111;
+  border: 1px solid #333;
+  padding: 1rem;
+  z-index: 10;
 }
 
 .message.user {


### PR DESCRIPTION
## Summary
- Import Chat component in App and pass connection status to HUD
- Restructure NeuroHUD to display status bar only
- Add layout and settings styles so Chat, HUD, and settings panel coexist

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2068efedc8325ae6ba6e4da5af785