### PR TITLE
docs: default to chroma vector backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ LOCAL_MODEL_PATH=./models/local-models/ggml-model.gguf
 # Embedding model identifier
 EMBEDDING_MODEL=text-embedding-3-large
 
-# Vector store backend
-VECTOR_BACKEND=faiss
+# Vector store backend (chroma or qdrant)
+VECTOR_BACKEND=chroma
 
 # Enable GPU acceleration (true/false)
 USE_GPU=false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ VEX's modular AI stack build that will include back and frontend API behaviour, 
 ## Setup
 1. Clone this repository.
 2. (Optional) Create a Python virtual environment.
-3. Copy `.env.example` to `.env` and update the values.
+3. Copy `.env.example` to `.env` and update the values (e.g. set `VECTOR_BACKEND`
+   to `chroma` or `qdrant`).
 4. Place any model files in the `models` directory.
 
 ## Quick Start

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from typing import Literal
+
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -30,7 +33,17 @@ class Settings(BaseSettings):
 
     # Model settings
     embedding_model: str | None = 'text-embedding-3-large'
-    vector_backend: str | None = 'faiss'
+    vector_backend: Literal["chroma", "qdrant"] = "chroma"
+
+    @field_validator("vector_backend", mode="before")
+    @classmethod
+    def _normalize_vector_backend(cls, v: str | None) -> str:
+        if v is None:
+            return "chroma"
+        v = v.lower()
+        if v not in {"chroma", "qdrant"}:
+            raise ValueError("VECTOR_BACKEND must be 'chroma' or 'qdrant'")
+        return v
 
     # Feature flags
     use_gpu: bool = False


### PR DESCRIPTION
## Summary
- default `VECTOR_BACKEND` env to `chroma`
- mention `qdrant` as optional vector store alternative
- validate and normalize `VECTOR_BACKEND` in settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c20697768c8325b852a305c3b3176a